### PR TITLE
Created root credential

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       ISSUER_WALLET_DID: ${ISSUER_WALLET_DID}
       HTTP_FORCE_CLOSE_CONNECTIONS: "true"
     networks:
-#local      - orgbook
+      - orgbook
       - myorg
     depends_on:
       - myorg-wallet-db
@@ -71,7 +71,7 @@ services:
       - POSTGRESQL_DATABASE=${POSTGRESQL_DATABASE}
       - POSTGRESQL_ADMIN_PASSWORD=${POSTGRESQL_ADMIN_PASSWORD}
     networks:
-#local      - orgbook
+      - orgbook
       - myorg
     ports:
       - 5435:5432
@@ -86,6 +86,6 @@ volumes:
 
 networks:
   myorg:
-#local  orgbook:
-#local    external:
-#local      name: tob_tob
+  orgbook:
+    external:
+      name: tob_tob

--- a/von-x-agent/config/routes.yml
+++ b/von-x-agent/config/routes.yml
@@ -1,29 +1,29 @@
 # Documentation: https://github.com/bcgov/von-agent-template/tree/master/von-x-agent/config
 
 forms:
-  my-permit:
+  paul-root-permit:
 
-    # URL for the Web form - becomes <server>/<path> e.g. http://localhost:5000/my-organization/my-permit
-    path: /my-organization/my-permit
+    # URL for the Web form - becomes <server>/<path> e.g. http://localhost:5000/paul-x-change/paul-root-permit
+    path: /paul-x-change/paul-root-permit
   
     # type is always "issue-credential"
     type: issue-credential
   
-    schema_name: my-permit.my-organization
-    page_title: my-org-full-name Permits
-    title: Application for my-permit
+    schema_name: paul-root-permit.paul-x-change
+    page_title: PaulXchange Permits
+    title: Application for paul-root-permit
   
     # Templates are defined in von-x-agent/templates
     template: bcgov.index.html
   
     description: >
-      my-org-full-name issues my-permit credentials to organizations to authorize those organizations to be able to do something.
+      PaulXchange issues paul-root-permit credentials to organizations to authorize those organizations to be able to do something.
   
-    explanation: Use the form below to apply for a my-permit for your organization.
+    explanation: Use the form below to apply for a paul-root-permit for your organization.
 
-    proof_request:
-      id: dflow_registration
-      connection_id: bctob
+    # proof_request:
+    #   id: dflow_registration
+    #   connection_id: bctob
 
     #js_includes:
     #  - src: js/bc_registries.js

--- a/von-x-agent/config/schemas.yml
+++ b/von-x-agent/config/schemas.yml
@@ -1,13 +1,14 @@
 # Documentation: https://github.com/bcgov/von-agent-template/tree/master/von-x-agent/config
 
-- name: my-permit.my-organization
+- name: paul-root-permit.paul-x-change
 
   version: '1.0.0'
-  description: The my-permit credential issued by my-org-full-name
-  path: /my-organization/my-permit
+  description: The paul-root-permit credential issued by PaulXchange
+  path: /paul-x-change/paul-root-permit
+
+  topic: corp_num
 
   attributes:
-    - corp_num
     - legal_name
     - permit_id
     - permit_type

--- a/von-x-agent/config/schemas.yml
+++ b/von-x-agent/config/schemas.yml
@@ -9,6 +9,7 @@
   topic: corp_num
 
   attributes:
+    - corp_num
     - legal_name
     - permit_id
     - permit_type

--- a/von-x-agent/config/services.yml
+++ b/von-x-agent/config/services.yml
@@ -1,12 +1,12 @@
 # Documentation: https://github.com/bcgov/von-agent-template/tree/master/von-x-agent/config
 
 issuers:
-  my-organization:
-    name: my-org-full-name
-    abbreviation: my-organization
-    url: https://www.my-organization.ca/my-organization-info-page
-    email: info@my-organization.ca
-    logo_path: ../assets/img/my-organization-logo.jpg
+  paul-x-change:
+    name: PaulXchange
+    abbreviation: paul-x-change
+    url: https://www.paul-x-change.ca/paul-x-change-info-page
+    email: info@paul-x-change.ca
+    logo_path: ../assets/img/paul-x-change-logo.jpg
     endpoint: $ENDPOINT_URL
 
     connection:
@@ -32,10 +32,10 @@ issuers:
 
     credential_types:
     - description: Permit
-      schema: my-permit.my-organization
-      issuer_url: $APPLICATION_URL/my-organization/my-permit
-      depends_on:
-        - dflow_registration
+      schema: paul-root-permit.paul-x-change
+      issuer_url: $APPLICATION_URL/paul-x-change/paul-root-permit
+      # depends_on:
+      #   - dflow_registration
       credential:
         effective_date:
           input: effective_date

--- a/von-x-agent/config/services.yml
+++ b/von-x-agent/config/services.yml
@@ -34,8 +34,6 @@ issuers:
     - description: Permit
       schema: paul-root-permit.paul-x-change
       issuer_url: $APPLICATION_URL/paul-x-change/paul-root-permit
-      # depends_on:
-      #   - dflow_registration
       credential:
         effective_date:
           input: effective_date

--- a/von-x-agent/config/services.yml
+++ b/von-x-agent/config/services.yml
@@ -54,6 +54,14 @@ issuers:
         # "value" identifies where to derive the data value (typically it comes from the claim)
         # "type" - if "value" - is the name of the attribute
         # "format" is an optional data format (default text)
+        - model: name
+          fields:
+            text:
+              input: legal_name
+              from: claim
+            type:
+              input: legal_name
+              from: value
         - model: attribute
           fields:
             type:

--- a/von-x-agent/config/settings.yml
+++ b/von-x-agent/config/settings.yml
@@ -1,13 +1,13 @@
 default:
-  APPLICATION_URL_VONX: $APPLICATION_URL/my-organization/my-permit
+  APPLICATION_URL_VONX: $APPLICATION_URL/paul-x-change/paul-root-permit
   TEMPLATE_PATH: ../templates
 
-  TOB_API_URL: TOBAPIURL
-  TOB_APP_URL: TOBAPPURL
+  TOB_API_URL: http://tob-api:8080/api/v2
+  TOB_APP_URL: http://localhost:8080
 
-  WALLET_SEED_VONX: my-organization_0000000000000000
+  WALLET_SEED_VONX: paul-x-change_000000000000000000
 
-  INDY_GENESIS_URL: GENESISURL
+  #INDY_GENESIS_URL: http://localhost:9000/genesis
 
   LEDGER_PROTOCOL_VERSION: "1.6"
   AUTO_REGISTER_DID: true


### PR DESCRIPTION
These are the steps required to create the root credential.

1. Follow the instructions in the [Getting Started Tutorial](https://github.com/bcgov/von-agent-template/blob/master/GettingStartedTutorial.md) and run the `init.sh` script with the appropriate parameters to initialize the environment.
2. Remove the dependency on the `dflow_registration` credential.
3. Specify which field to use as `topic_id for the new credential.
4. Add the correct mapping to see results in TheOrgBook search results

Changes 2, 3 and 4 are pointed out in a comment.

Once the credential is issued, it should be searchable in TheOrgBook by using the given legal name